### PR TITLE
Handle three isotopes nicherover

### DIFF
--- a/R/extract_mu.R
+++ b/R/extract_mu.R
@@ -11,10 +11,8 @@
 #' @param pkg a `character` string that is the name of the package that
 #' you're using. Defaults to `"nicheROVER"`.
 #' Alternatively the user can supply the argument with `"SIBER"`.
-#' @param isotope_a a `character` string to change the column name
-#' of the first isotope used in the analysis. Defaults to `"d13c"`.
-#' @param isotope_b a `character` string to change the name of second isotope
-#' used in the analysis. Defaults to `"d15n"`.
+#' @param isotope_name is a vector of `character` string used change the column name
+#' of isotopes used in the analysis. Defaults to `c("d13c", "d15n")`.
 #' @param data_format a `character` string that decides whether the returned object is
 #' in long or wide format. Default is `"long"`, with the alternative supplied
 #' being `"wide"`.

--- a/R/extract_mu.R
+++ b/R/extract_mu.R
@@ -11,7 +11,7 @@
 #' @param pkg a `character` string that is the name of the package that
 #' you're using. Defaults to `"nicheROVER"`.
 #' Alternatively the user can supply the argument with `"SIBER"`.
-#' @param isotope_name is a vector of `character` string used change the column name
+#' @param isotope_names is a vector of `character` string used change the column name
 #' of isotopes used in the analysis. Defaults to `c("d13c", "d15n")`.
 #' @param data_format a `character` string that decides whether the returned object is
 #' in long or wide format. Default is `"long"`, with the alternative supplied

--- a/R/extract_mu.R
+++ b/R/extract_mu.R
@@ -80,8 +80,7 @@
 
 extract_mu <- function(data,
                        pkg = NULL,
-                       isotope_a = NULL,
-                       isotope_b = NULL,
+                       isotope_names = NULL,
                        data_format = NULL,
                        community_df = NULL) {
 
@@ -100,23 +99,26 @@ extract_mu <- function(data,
     cli::cli_abort("Invalid characters for 'pkg'. Allowed character strings are
                    'nicheROVER' or 'SIBER'.")
   }
+
   # defaults of isotpoe a and b
-  if (is.null(isotope_a)) {
-    isotope_a <- "d13c"
+  if (is.null(isotope_names)) {
+    isotope_names <- c("d13c", "d15n")
   }
 
-  if (is.null(isotope_b)) {
-    isotope_b <- "d15n"
-  }
-  # Check if isotope_a is character
-  if (!is.character(isotope_a)) {
-    cli::cli_abort("The supplied argument for 'isotope_a' must be a character.")
+  # Check if isotope_names is a character vector
+  if (!is.vector(isotope_names) || !is.character(isotope_names)) {
+    cli::cli_abort("The supplied argument for 'isotope_names' must be a vector of characters.")
   }
 
-  # Check if isotope_b is character
-  if (!is.character(isotope_b)) {
-    cli::cli_abort("The supplied argument for 'isotope_b' must be a character.")
+  # Check if isotope_names has exactly 2 elements
+  if (length(isotope_names) != 2) {
+    cli::cli_abort("The 'isotope_names' vector must have exactly 2 elements, representing isotope_a and isotope_b.")
   }
+
+  # # Check if isotope_b is character
+  # if (!is.character(isotope_b)) {
+  #   cli::cli_abort("The supplied argument for 'isotope_b' must be a character.")
+  # }
 
 
   # sett data formatt
@@ -167,6 +169,7 @@ extract_mu <- function(data,
     if (data_format %in% "wide") {
       return(df_mu)
     }
+
   }
   if (pkg %in% "SIBER") {
 
@@ -190,7 +193,7 @@ extract_mu <- function(data,
     }
 
 
-    id_isotope <- c(isotope_a, isotope_b)
+    id_isotope <- isotope_names
 
 
     df_mu <- data |>
@@ -225,7 +228,7 @@ extract_mu <- function(data,
       left_join(community_df, by = c("community",
                                      "group")) %>%
       dplyr::select(metric:sample_number, community_name,
-                      group_name, isotope, mu_est)
+                    group_name, isotope, mu_est)
 
     if (data_format %in% "long") {
 

--- a/R/extract_sigma.R
+++ b/R/extract_sigma.R
@@ -11,10 +11,10 @@
 #' @param pkg a `character` string that is the name of the package that
 #' you're using. Defaults to `"nicheROVER"`.
 #' Alternatively the user can supply the argument with `"SIBER"`.
-#' @param isotope_a a `character` string to change the column name
-#' of the first isotope used in the analysis. Defaults to `"d13c"`.
-#' @param isotope_b a `character` string to change the name of second isotope
-#' used in the analysis. Defaults to `"d15n"`.
+#' @param isotope_n a `numeric` either `2` or `3` that is the number of isotopes
+#' used in the anlsysis. Will default to `2`.
+#' @param isotope_names is a vector of `character` string used change the column name
+#' of isotopes used in the analysis. Defaults to `c("d13c", "d15n")`.
 #' @param data_format a `character` string that decides whether the returned object is
 #' in long or wide format. Default is `"wide"`, with the alternative supplied being `"long"`.
 #'

--- a/R/extract_sigma.R
+++ b/R/extract_sigma.R
@@ -146,6 +146,8 @@ extract_sigma <-  function(data,
       tidyr::separate(isotope, into = c("isotope", "sample_number"),
                       sep = "\\.")
 
+
+
     if (data_format %in% "wide") {
 
       df_sigma <- df_sigma |>
@@ -159,11 +161,25 @@ extract_sigma <-  function(data,
     }
   }
 
+
   if (pkg %in% "SIBER") {
     if (!inherits(data, "list")) {
       cli::cli_abort("Input 'data' must be a list.")
     }
 
+    if (is.null(isotope_names)) {
+      isotope_names <- c("d13c", "d15n")
+    }
+
+    # Check if isotope_names is a character vector
+    if (!is.vector(isotope_names) || !is.character(isotope_names)) {
+      cli::cli_abort("The supplied argument for 'isotope_names' must be a vector of characters.")
+    }
+
+    # Check if isotope_names has exactly 2 elements
+    if (length(isotope_names) != 2) {
+      cli::cli_abort("The 'isotope_names' vector must have exactly 2 elements, representing isotope_a and isotope_b.")
+    }
     # create name vector that will be used to id isotopes.
     id_isotope <- isotope_names
 
@@ -226,3 +242,4 @@ extract_sigma <-  function(data,
     }
   }
 }
+

--- a/R/extract_sigma.R
+++ b/R/extract_sigma.R
@@ -72,55 +72,6 @@ extract_sigma <-  function(data,
     strings are 'wide' or 'long'.")
   }
 
-  if (is.null(isotope_n)) {
-    isotope_n <- 2
-  }
-  if (!is.numeric(isotope_n) || !(isotope_n %in% c(2, 3))) {
-    cli::cli_abort("Argument 'isotope_n' must be a numeric value and either 2 or 3.")
-  }
-
-  if (isotope_n == 2) {
-  # defaults of isotpoe a and b
-  if (is.null(isotope_names)) {
-    isotope_names <- c("d13c", "d15n")
-  }
-
-  # Check if isotope_names is a character vector
-  if (!is.vector(isotope_names) || !is.character(isotope_names)) {
-    cli::cli_abort("The supplied argument for 'isotope_names' must be a vector of characters.")
-  }
-
-  # Check if isotope_names has exactly 2 elements
-  if (length(isotope_names) != 2) {
-    cli::cli_abort("The 'isotope_names' vector must have exactly 2 elements, representing isotope_a and isotope_b.")
-  }
-  }
-  if (isotope_n == 3){
-    # defaults of isotpoe a and b
-    if (is.null(isotope_names)) {
-      isotope_names <- c("d13c", "d15n", "d34s")
-    }
-
-    # Check if isotope_names is a character vector
-    if (!is.vector(isotope_names) || !is.character(isotope_names)) {
-      cli::cli_abort("The supplied argument for 'isotope_names' must be a vector of characters.")
-    }
-
-    # Check if isotope_names has exactly 2 elements
-    if (length(isotope_names) != 3) {
-      cli::cli_abort("The 'isotope_names' vector must have exactly 3 elements, representing isotope_a and isotope_b.")
-    }
-  }
-
-  # # Check if isotope_a is character
-  # if (!is.character(isotope_a)) {
-  #   cli::cli_abort("The supplied argument for 'isotope_a' must be a character.")
-  # }
-  #
-  # # Check if isotope_b is character
-  # if (!is.character(isotope_b)) {
-  #   cli::cli_abort("The supplied argument for 'isotope_b' must be a character.")
-  # }
 
   if (pkg %in% "nicheROVER") {
     # Check if data is a list
@@ -128,6 +79,44 @@ extract_sigma <-  function(data,
       cli::cli_abort("Input 'data' must be a list.")
     }
     # create name vector that will be used to id isotopes.
+    if (is.null(isotope_n)) {
+      isotope_n <- 2
+    }
+    if (!is.numeric(isotope_n) || !(isotope_n %in% c(2, 3))) {
+      cli::cli_abort("Argument 'isotope_n' must be a numeric value and either 2 or 3.")
+    }
+
+    if (isotope_n == 2) {
+      if (is.null(isotope_names)) {
+        isotope_names <- c("d13c", "d15n")
+      }
+
+      # Check if isotope_names is a character vector
+      if (!is.vector(isotope_names) || !is.character(isotope_names)) {
+        cli::cli_abort("The supplied argument for 'isotope_names' must be a vector of characters.")
+      }
+
+      # Check if isotope_names has exactly 2 elements
+      if (length(isotope_names) != 2) {
+        cli::cli_abort("The 'isotope_names' vector must have exactly 2 elements, representing isotope_a and isotope_b.")
+      }
+    }
+    if (isotope_n == 3) {
+      # defaults of isotpoe a and b
+      if (is.null(isotope_names)) {
+        isotope_names <- c("d13c", "d15n", "d34s")
+      }
+
+      # Check if isotope_names is a character vector
+      if (!is.vector(isotope_names) || !is.character(isotope_names)) {
+        cli::cli_abort("The supplied argument for 'isotope_names' must be a vector of characters.")
+      }
+
+      # Check if isotope_names has exactly 2 elements
+      if (length(isotope_names) != 3) {
+        cli::cli_abort("The 'isotope_names' vector must have exactly 3 elements, representing isotope_a,  isotope_b, and isotope_c.")
+      }
+    }
     id_isotope <- isotope_names
     # extract sigma
     df_sigma <- purrr::map(data, purrr::pluck, 2) |>

--- a/R/extract_sigma.R
+++ b/R/extract_sigma.R
@@ -47,8 +47,8 @@
 
 extract_sigma <-  function(data,
                            pkg = NULL,
-                           isotope_a = NULL,
-                           isotope_b = NULL,
+                           isotope_n = NULL,
+                           isotope_names = NULL,
                            data_format = NULL) {
 
   # Set pkg to "nicheROVER" if it is NULL
@@ -72,23 +72,55 @@ extract_sigma <-  function(data,
     strings are 'wide' or 'long'.")
   }
 
+  if (is.null(isotope_n)) {
+    isotope_n <- 2
+  }
+  if (!is.numeric(isotope_n) || !(isotope_n %in% c(2, 3))) {
+    cli::cli_abort("Argument 'isotope_n' must be a numeric value and either 2 or 3.")
+  }
+
+  if (isotope_n == 2) {
   # defaults of isotpoe a and b
-  if (is.null(isotope_a)) {
-    isotope_a <- "d13c"
+  if (is.null(isotope_names)) {
+    isotope_names <- c("d13c", "d15n")
   }
 
-  if (is.null(isotope_b)) {
-    isotope_b <- "d15n"
-  }
-  # Check if isotope_a is character
-  if (!is.character(isotope_a)) {
-    cli::cli_abort("The supplied argument for 'isotope_a' must be a character.")
+  # Check if isotope_names is a character vector
+  if (!is.vector(isotope_names) || !is.character(isotope_names)) {
+    cli::cli_abort("The supplied argument for 'isotope_names' must be a vector of characters.")
   }
 
-  # Check if isotope_b is character
-  if (!is.character(isotope_b)) {
-    cli::cli_abort("The supplied argument for 'isotope_b' must be a character.")
+  # Check if isotope_names has exactly 2 elements
+  if (length(isotope_names) != 2) {
+    cli::cli_abort("The 'isotope_names' vector must have exactly 2 elements, representing isotope_a and isotope_b.")
   }
+  }
+  if (isotope_n == 3){
+    # defaults of isotpoe a and b
+    if (is.null(isotope_names)) {
+      isotope_names <- c("d13c", "d15n", "d34s")
+    }
+
+    # Check if isotope_names is a character vector
+    if (!is.vector(isotope_names) || !is.character(isotope_names)) {
+      cli::cli_abort("The supplied argument for 'isotope_names' must be a vector of characters.")
+    }
+
+    # Check if isotope_names has exactly 2 elements
+    if (length(isotope_names) != 3) {
+      cli::cli_abort("The 'isotope_names' vector must have exactly 3 elements, representing isotope_a and isotope_b.")
+    }
+  }
+
+  # # Check if isotope_a is character
+  # if (!is.character(isotope_a)) {
+  #   cli::cli_abort("The supplied argument for 'isotope_a' must be a character.")
+  # }
+  #
+  # # Check if isotope_b is character
+  # if (!is.character(isotope_b)) {
+  #   cli::cli_abort("The supplied argument for 'isotope_b' must be a character.")
+  # }
 
   if (pkg %in% "nicheROVER") {
     # Check if data is a list
@@ -96,7 +128,7 @@ extract_sigma <-  function(data,
       cli::cli_abort("Input 'data' must be a list.")
     }
     # create name vector that will be used to id isotopes.
-    id_isotope <- c(isotope_a, isotope_b)
+    id_isotope <- isotope_names
     # extract sigma
     df_sigma <- purrr::map(data, purrr::pluck, 2) |>
       purrr::imap(~ tibble::as_tibble(.x) |>
@@ -133,7 +165,10 @@ extract_sigma <-  function(data,
     }
 
     # create name vector that will be used to id isotopes.
-    id_isotope <- c(isotope_a, isotope_b)
+    id_isotope <- isotope_names
+
+    isotope_a <- isotope_names[1]
+    isotope_b <- isotope_names[2]
 
 
     df_sigma <- data |>

--- a/man/extract_mu.Rd
+++ b/man/extract_mu.Rd
@@ -22,6 +22,9 @@ or \href{https://cran.r-project.org/package=SIBER}{{SIBER}}, respectfully.}
 you're using. Defaults to \code{"nicheROVER"}.
 Alternatively the user can supply the argument with \code{"SIBER"}.}
 
+\item{isotope_names}{is a vector of \code{character} string used change the column name
+of isotopes used in the analysis. Defaults to \code{c("d13c", "d15n")}.}
+
 \item{data_format}{a \code{character} string that decides whether the returned object is
 in long or wide format. Default is \code{"long"}, with the alternative supplied
 being \code{"wide"}.}
@@ -37,9 +40,6 @@ required by the function, \code{createSiberObject()}
 from \href{https://CRAN.R-project.org/package=SIBER}{{SIBER}}.
 The third and fourth columns contains the actual names of the communities
 and groups the user is working with (e.g., \code{"region"}, \code{"common_name"}).}
-
-\item{isotope_name}{is a vector of \code{character} string used change the column name
-of isotopes used in the analysis. Defaults to \code{c("d13c", "d15n")}.}
 }
 \value{
 Returns a \code{tibble} of extracted estimates of \eqn{\mu} created by the

--- a/man/extract_mu.Rd
+++ b/man/extract_mu.Rd
@@ -7,8 +7,7 @@
 extract_mu(
   data,
   pkg = NULL,
-  isotope_a = NULL,
-  isotope_b = NULL,
+  isotope_names = NULL,
   data_format = NULL,
   community_df = NULL
 )
@@ -22,12 +21,6 @@ or \href{https://cran.r-project.org/package=SIBER}{{SIBER}}, respectfully.}
 \item{pkg}{a \code{character} string that is the name of the package that
 you're using. Defaults to \code{"nicheROVER"}.
 Alternatively the user can supply the argument with \code{"SIBER"}.}
-
-\item{isotope_a}{a \code{character} string to change the column name
-of the first isotope used in the analysis. Defaults to \code{"d13c"}.}
-
-\item{isotope_b}{a \code{character} string to change the name of second isotope
-used in the analysis. Defaults to \code{"d15n"}.}
 
 \item{data_format}{a \code{character} string that decides whether the returned object is
 in long or wide format. Default is \code{"long"}, with the alternative supplied
@@ -44,6 +37,9 @@ required by the function, \code{createSiberObject()}
 from \href{https://CRAN.R-project.org/package=SIBER}{{SIBER}}.
 The third and fourth columns contains the actual names of the communities
 and groups the user is working with (e.g., \code{"region"}, \code{"common_name"}).}
+
+\item{isotope_name}{is a vector of \code{character} string used change the column name
+of isotopes used in the analysis. Defaults to \code{c("d13c", "d15n")}.}
 }
 \value{
 Returns a \code{tibble} of extracted estimates of \eqn{\mu} created by the

--- a/man/extract_sigma.Rd
+++ b/man/extract_sigma.Rd
@@ -7,8 +7,8 @@
 extract_sigma(
   data,
   pkg = NULL,
-  isotope_a = NULL,
-  isotope_b = NULL,
+  isotope_n = NULL,
+  isotope_names = NULL,
   data_format = NULL
 )
 }
@@ -22,11 +22,11 @@ or \href{https://cran.r-project.org/package=SIBER}{{SIBER}}, respectfully.}
 you're using. Defaults to \code{"nicheROVER"}.
 Alternatively the user can supply the argument with \code{"SIBER"}.}
 
-\item{isotope_a}{a \code{character} string to change the column name
-of the first isotope used in the analysis. Defaults to \code{"d13c"}.}
+\item{isotope_n}{a \code{numeric} either \code{2} or \code{3} that is the number of isotopes
+used in the anlsysis. Will default to \code{2}.}
 
-\item{isotope_b}{a \code{character} string to change the name of second isotope
-used in the analysis. Defaults to \code{"d15n"}.}
+\item{isotope_names}{is a vector of \code{character} string used change the column name
+of isotopes used in the analysis. Defaults to \code{c("d13c", "d15n")}.}
 
 \item{data_format}{a \code{character} string that decides whether the returned object is
 in long or wide format. Default is \code{"wide"}, with the alternative supplied being \code{"long"}.}

--- a/tests/testthat/test-extract_mu.R
+++ b/tests/testthat/test-extract_mu.R
@@ -95,19 +95,35 @@ test_that("test that isotope a and b error when not characters ", {
   expect_error(extract_mu(
     data = niw_fish_post,
     data_format = "wide",
-    isotope_a = 1
-  ), "The supplied argument for 'isotope_a' must be a character.")
+    isotope_names = 1
+  ), "The supplied argument for 'isotope_names' must be a vector of characters.")
 
 })
-
 test_that("test that isotope a and b error when not characters ", {
   expect_error(extract_mu(
     data = niw_fish_post,
     data_format = "wide",
-    isotope_b = 1
-  ), "The supplied argument for 'isotope_b' must be a character.")
+    isotope_names = c(1, 2)
+  ), "The supplied argument for 'isotope_names' must be a vector of characters.")
 
 })
+test_that("test that isotope a and b error when not characters ", {
+  expect_error(extract_mu(
+    data = niw_fish_post,
+    data_format = "wide",
+    isotope_names = c("d13c")
+  ), "The 'isotope_names' vector must have exactly 2 elements, representing isotope_a and isotope_b.")
+
+})
+
+# test_that("test that isotope a and b error when not characters ", {
+#   expect_error(extract_mu(
+#     data = niw_fish_post,
+#     data_format = "wide",
+#     isotope_b = 1
+#   ), "The supplied argument for 'isotope_b' must be a character.")
+#
+# })
 
 
 test_that("Check if column order", {

--- a/tests/testthat/test-extract_sigma.R
+++ b/tests/testthat/test-extract_sigma.R
@@ -10,17 +10,17 @@ test_that("test if it doesn't error with basic niw object ", {
 })
 test_that("test if it wide-long 't error with basic niw object ", {
   expect_error(extract_sigma(
-      data = niw_fish_post,
-      data_format = "x"
-    ), "Invalid characters for 'data_format'. Allowed character strings are 'wide' or 'long'.")
+    data = niw_fish_post,
+    data_format = "x"
+  ), "Invalid characters for 'data_format'. Allowed character strings are 'wide' or 'long'.")
 
 
 })
 test_that("test if pkg 't error with basic niw object ", {
   expect_error(extract_sigma(
-      data = niw_fish_post,
-      pkg = "nicherover"
-    ), "Invalid characters for 'pkg'. Allowed character strings are 'nicheROVER' or 'SIBER'.")
+    data = niw_fish_post,
+    pkg = "nicherover"
+  ), "Invalid characters for 'pkg'. Allowed character strings are 'nicheROVER' or 'SIBER'.")
 
 
 })
@@ -92,12 +92,11 @@ test_that("test that the object type and length are correct ", {
 test_that("that supplying both isotope names works ", {
   df <- extract_sigma(
     data = niw_fish_post,
-    isotope_a = "cal_d13c",
-    isotope_b = "cal_d15n",
+    isotope_names = c("cal_d13c","cal_d15n"),
     data_format = "long"
 
   )
- expect_type(object = df$id, type = "character")
+  expect_type(object = df$id, type = "character")
 
   expect_match(object = df$id, regexp = "cal_d13c", all = FALSE)
   expect_match(object = df$id, regexp = "cal_d15n", all = FALSE)
@@ -107,15 +106,22 @@ test_that("that supplying both isotope names works ", {
 test_that("that isotope a and b will throw erros if charcter not supplied", {
   expect_error(df <- extract_sigma(
     data = niw_fish_post,
-    isotope_a = 10,
+    isotope_names = 10,
 
-  ), regexp = "The supplied argument for 'isotope_a' must be a character."
+  ), regexp = "The supplied argument for 'isotope_names' must be a vector of characters"
   )
   expect_error(df <- extract_sigma(
     data = niw_fish_post,
-    isotope_b = 10,
+    isotope_names = c(10, 11),
 
-  ), regexp = "The supplied argument for 'isotope_b' must be a character"
+  ), regexp = "The supplied argument for 'isotope_names' must be a vector of characters."
+  )
+
+  expect_error(df <- extract_sigma(
+    data = niw_fish_post,
+    isotope_names = c("10"),
+
+  ), regexp = "The 'isotope_names' vector must have exactly 2 elements, representing isotope_a and isotope_b."
   )
 
 }
@@ -205,8 +211,7 @@ test_that("that supplying both isotope names works ", {
   df <- extract_sigma(
     data = post_sam_siber,
     pkg = "SIBER",
-    isotope_a = "cal_d15n",
-    isotope_b = "cal_d13c",
+    isotope_names = c("cal_d15n", "cal_d13c"),
     data_format = "long"
 
   )
@@ -220,16 +225,23 @@ test_that("that supplying both isotope names works ", {
 test_that("that isotope a and b will throw erros if charcter not supplied", {
   expect_error(df <- extract_sigma(
     data = niw_fish_post,
-    isotope_a = 10,
+    isotope_names = 10,
 
-  ), regexp = "The supplied argument for 'isotope_a' must be a character."
+  ), regexp = "The supplied argument for 'isotope_names' must be a vector of characters"
   )
   expect_error(df <- extract_sigma(
     data = niw_fish_post,
-    isotope_b = 10,
+    isotope_names = c(10, 11)
 
-  ), regexp = "The supplied argument for 'isotope_b' must be a character"
+  ), regexp = "The supplied argument for 'isotope_names' must be a vector of characters"
   )
+  expect_error(df <- extract_sigma(
+    data = niw_fish_post,
+    isotope_names = c("10")
+
+  ), regexp = "The 'isotope_names' vector must have exactly 2 elements, representing isotope_a and isotope_b."
+  )
+
 
 }
 )

--- a/tests/testthat/test-extract_sigma.R
+++ b/tests/testthat/test-extract_sigma.R
@@ -1,4 +1,5 @@
 
+
 # unit test for extract_sigma
 test_that("test if it doesn't error with basic niw object ", {
   expect_no_error(
@@ -126,6 +127,33 @@ test_that("that isotope a and b will throw erros if charcter not supplied", {
 
 }
 )
+
+df <- nicheROVER::fish %>%
+  janitor::clean_names()
+
+## ----message = FALSE--------------------------------------------------------------------------------------------------------------------------------------------------
+nsample <- 1000
+
+## ----message = FALSE--------------------------------------------------------------------------------------------------------------------------------------------------
+fish_par <- df %>%
+  split(.$species) %>%
+  map(~ select(., d13c, d15n, d34s)) %>%
+  map(~ nicheROVER::niw.post(nsample = nsample, X = .))
+
+test_that("test isotope_n to be 3", {
+  ### test isotope_n
+  expect_no_error(
+    extract_sigma(
+    data = fish_par,
+    isotope_n = 3,
+  )
+  )
+
+}
+)
+
+
+
 
 
 test_that("test if it doesn't error with basic siber object ", {


### PR DESCRIPTION
- `extract_mu()` now has `isotope_names` argument instead of `isotope_a` and `isotope_b`. This argument takes a vector that are character strings that are isotope a and b 

- `extract_sigma()` now has `isotope_names` and `isotope_n` which is the number of isotopes used in the analysis. `isotope_names` is the same above except when `isotope_n` is 3, `isotope_names` defaults to adding a third isotope name in `"d34s".  