### PR TITLE
Handle three isotopes niche rover

### DIFF
--- a/R/extract_sigma.R
+++ b/R/extract_sigma.R
@@ -136,14 +136,33 @@ extract_sigma <-  function(data,
       if (length(isotope_names) != 3) {
         cli::cli_abort("The 'isotope_names' vector must have exactly 3 elements, representing isotope_a,  isotope_b, and isotope_c.")
       }
+
+      df_sigma <- purrr::map(data, purrr::pluck, 2) |>
+        purrr::imap(~ tibble::as_tibble(.x))
+
+      isotope_number <- df_sigma |>
+        purrr::map(~ nrow(.x)) |>
+        dplyr::bind_rows(.id = "isotope_num") |>
+        dplyr::mutate(
+          id = 1
+        ) %>%
+        tidyr::pivot_longer(-id)
+
+      isotope_length <- unique(isotope_number$value)
+
+      if (isotope_length != 3) {
+        cli::cli_abort("Argument 'isotope_n' does not match the number of isotopes
+                       being used.")
+      }
+
     }
-    id_isotope <- isotope_names
+
     # extract sigma
-    df_sigma <- purrr::map(data, purrr::pluck, 2) |>
-      purrr::imap(~ tibble::as_tibble(.x) |>
+    df_sigma_extract <- df_sigma |>
+      purrr::imap(~ .x |>
                     dplyr::mutate(
                       metric = "sigma",
-                      id = id_isotope,
+                      id = isotope_names,
                       sample_name = .y
                     )
       ) |>

--- a/R/extract_sigma.R
+++ b/R/extract_sigma.R
@@ -178,13 +178,13 @@ extract_sigma <-  function(data,
 
     if (data_format %in% "wide") {
 
-      df_sigma <- df_sigma |>
+      df_sigma_extract <- df_sigma_extract |>
         tidyr::pivot_wider(names_from = id,
                            values_from = post_sample)
-      return(df_sigma)
+      return(df_sigma_extract)
     }
     if (data_format %in% "long") {
-      return(df_sigma)
+      return(df_sigma_extract)
 
     }
   }

--- a/R/extract_sigma.R
+++ b/R/extract_sigma.R
@@ -100,7 +100,27 @@ extract_sigma <-  function(data,
       if (length(isotope_names) != 2) {
         cli::cli_abort("The 'isotope_names' vector must have exactly 2 elements, representing isotope_a and isotope_b.")
       }
-    }
+
+      df_sigma <- purrr::map(data, purrr::pluck, 2) |>
+        purrr::imap(~ tibble::as_tibble(.x))
+
+      isotope_number <- df_sigma |>
+        purrr::map(~ nrow(.x)) |>
+        dplyr::bind_rows(.id = "isotope_num") |>
+        dplyr::mutate(
+          id = 1
+        ) %>%
+        tidyr::pivot_longer(-id)
+
+      isotope_length <- unique(isotope_number$value)
+
+      if (isotope_length != 2) {
+        cli::cli_abort("Argument 'isotope_n' does not match the number of isotopes
+                       being used.")
+      }
+
+      }
+
     if (isotope_n == 3) {
       # defaults of isotpoe a and b
       if (is.null(isotope_names)) {

--- a/tests/testthat/test-extract_sigma.R
+++ b/tests/testthat/test-extract_sigma.R
@@ -144,13 +144,92 @@ test_that("test isotope_n to be 3", {
   ### test isotope_n
   expect_no_error(
     extract_sigma(
-    data = fish_par,
-    isotope_n = 3,
-  )
+      data = fish_par,
+      isotope_n = 3,
+    )
   )
 
 }
 )
+
+test_that("test error when isotope_n = 2 or 3", {
+
+  expect_error(
+    extract_sigma(
+      data = fish_par,
+      isotope_n = 2
+    ),
+    regex = "Argument 'isotope_n' does not match the number of isotopes being used."
+  )
+}
+)
+test_that("test error when isotope_n = 3 but names do not work", {
+
+  expect_error(
+    extract_sigma(
+      data = fish_par,
+      isotope_n = 3,
+      isotope_names = c("d_13c", "d_15n")
+    ),
+    regex = "The 'isotope_names' vector must have exactly 3 elements, representing isotope_a, isotope_b, and isotope_c."
+  )
+
+  expect_error(
+    extract_sigma(
+      data = niw_fish_post,
+      isotope_n = 3,
+      isotope_names = c(1)
+    ), "The supplied argument for 'isotope_names' must be a vector of characters."
+  )
+}
+)
+test_that("test error when isotope_n = 3 but names do not work", {
+
+  expect_error(
+    extract_sigma(
+      data = niw_fish_post,
+      isotope_n = 2,
+      isotope_names = c("d_13c")
+    ),
+    regex = "The 'isotope_names' vector must have exactly 2 elements, representing isotope_a and isotope_b."
+  )
+  expect_error(
+    extract_sigma(
+      data = niw_fish_post,
+      isotope_n = 2,
+      isotope_names = c(1)
+    ), "The supplied argument for 'isotope_names' must be a vector of characters."
+  )
+
+}
+)
+
+
+
+test_that("test error when isotope_n = 2 or 3", {
+
+  expect_error(
+    extract_sigma(
+      data = niw_fish_post,
+      isotope_n = 3
+    ),
+    regex = "Argument 'isotope_n' does not match the number of isotopes being used."
+  )
+}
+)
+test_that("test error when isotope_n = 2 or 3", {
+
+  expect_error(
+    extract_sigma(
+      data = niw_fish_post,
+      isotope_n = 4
+    ),
+    regex = "Argument 'isotope_n' must be a numeric value and either 2 or 3"
+  )
+}
+)
+
+
 
 
 
@@ -250,27 +329,8 @@ test_that("that supplying both isotope names works ", {
 
 }
 )
-test_that("that isotope a and b will throw erros if charcter not supplied", {
-  expect_error(df <- extract_sigma(
-    data = niw_fish_post,
-    isotope_names = 10,
-
-  ), regexp = "The supplied argument for 'isotope_names' must be a vector of characters"
-  )
-  expect_error(df <- extract_sigma(
-    data = niw_fish_post,
-    isotope_names = c(10, 11)
-
-  ), regexp = "The supplied argument for 'isotope_names' must be a vector of characters"
-  )
-  expect_error(df <- extract_sigma(
-    data = niw_fish_post,
-    isotope_names = c("10")
-
-  ), regexp = "The 'isotope_names' vector must have exactly 2 elements, representing isotope_a and isotope_b."
-  )
 
 
-}
-)
+
+
 


### PR DESCRIPTION
- Updated `isotope_n` and `isotope_name` arguments to handle `2` or `3`. Added tests to check this. 